### PR TITLE
Add support for replacing listeners

### DIFF
--- a/spacy_curated_transformers/models/listeners.py
+++ b/spacy_curated_transformers/models/listeners.py
@@ -1,34 +1,27 @@
-from typing import (
-    Any,
-    Callable,
-    Iterable,
-    List,
-    Optional,
-    Tuple,
-)
+from typing import Any, Callable, Iterable, List, Optional, Tuple
 
 from spacy import Errors as SpacyErrors
 from spacy.tokens import Doc
-from thinc.model import Model
-from thinc.types import Ragged, Floats2d
 
-from .output import TransformerModelOutput
-from .pooling import with_ragged_layers, with_ragged_last_layer
-from .types import (
-    WithRaggedLayersModelT,
-    WithRaggedLastLayerModelT,
-    PoolingModelT,
-    ScalarWeightOutT,
-    ScalarWeightModelT,
-)
-from .output import TransformerModelOutput
-from .pooling import with_ragged_layers, with_ragged_last_layer
-from .types import (
-    WithRaggedLayersModelT,
-    WithRaggedLastLayerModelT,
-    PoolingModelT,
-)
+from thinc.api import Model, deserialize_attr, serialize_attr
+from thinc.types import Floats2d, Ragged
+
 from ..errors import Errors
+from .output import TransformerModelOutput
+from .pooling import with_ragged_last_layer, with_ragged_layers
+from .types import (
+    PoolingModelT,
+    ScalarWeightModelT,
+    ScalarWeightOutT,
+    TransformerListenerModelT,
+    TransformerModelT,
+    WithRaggedLastLayerModelT,
+    WithRaggedLayersModelT,
+    WrappedTransformerAndListenerBackpropT,
+    WrappedTransformerAndListenerInT,
+    WrappedTransformerAndListenerModelT,
+    WrappedTransformerAndListenerOutT,
+)
 
 
 def build_transformer_layers_listener_v1(
@@ -37,7 +30,7 @@ def build_transformer_layers_listener_v1(
     pooling: PoolingModelT,
     upstream: str = "*",
     grad_factor: float = 1.0,
-) -> Model[List[Doc], List[Floats2d]]:
+) -> TransformerListenerModelT:
     """Construct a listener layer that communicates with one or more upstream Transformer
     components. This layer extracts the output of all transformer layers and performs
     pooling over the individual pieces of each Doc token, returning their corresponding
@@ -63,14 +56,14 @@ def build_transformer_layers_listener_v1(
     grad_factor (float):
         Factor to multiply gradients with.
     """
-    transformer = TransformerLayersListener(
+    listener = TransformerLayersListener.new(
         upstream_name=upstream,
         pooling=pooling,
         layers=layers,
         width=width,
         grad_factor=grad_factor,
     )
-    return transformer
+    return listener
 
 
 def build_last_transformer_layer_listener_v1(
@@ -78,7 +71,7 @@ def build_last_transformer_layer_listener_v1(
     pooling: PoolingModelT,
     upstream: str = "*",
     grad_factor: float = 1.0,
-) -> Model[List[Doc], List[Floats2d]]:
+) -> TransformerListenerModelT:
     """Construct a listener layer that communicates with one or more upstream Transformer
     components. This layer extracts the output of the last transformer layer and performs
     pooling over the individual pieces of each Doc token, returning their corresponding
@@ -101,10 +94,10 @@ def build_last_transformer_layer_listener_v1(
     grad_factor (float):
         Factor to multiply gradients with.
     """
-    transformer = LastTransformerLayerListener(
+    listener = LastTransformerLayerListener.new(
         upstream_name=upstream, pooling=pooling, width=width, grad_factor=grad_factor
     )
-    return transformer
+    return listener
 
 
 def build_scalar_weighting_listener_v1(
@@ -113,7 +106,7 @@ def build_scalar_weighting_listener_v1(
     pooling: PoolingModelT,
     upstream: str = "*",
     grad_factor: float = 1.0,
-) -> Model[List[Doc], List[Floats2d]]:
+) -> TransformerListenerModelT:
     """Construct a listener layer that communicates with one or more upstream Transformer
     components. This layer calculates a weighted representation of all transformer layer
     outputs and performs pooling over the individual pieces of each Doc token, returning
@@ -141,17 +134,39 @@ def build_scalar_weighting_listener_v1(
     grad_factor (float):
         Factor to multiply gradients with.
     """
-    transformer = ScalarWeightingListener(
+    listener = ScalarWeightingListener.new(
         upstream_name=upstream,
         weighting=weighting,
         pooling=pooling,
         width=width,
         grad_factor=grad_factor,
     )
-    return transformer
+    return listener
 
 
-class TransformerListener(Model):
+# We need to store the listener state in the attributes dict of the listener model.
+# This custom class is used to ensure that this state is not serialized to disk.
+class _ListenerNonPersistentState:
+    batch_id: Optional[int] = None
+    outputs: Optional[TransformerModelOutput] = None
+    backprop: Optional[Callable[[List[List[Ragged]], Tuple[int]], Any]] = None
+
+
+@serialize_attr.register(_ListenerNonPersistentState)
+def serialize_listener_non_persistent_state(
+    _, value: _ListenerNonPersistentState, name: str, model
+) -> bytes:
+    return bytes()
+
+
+@deserialize_attr.register(_ListenerNonPersistentState)
+def deserialize_listener_non_persistent_state(
+    _, value: bytes, name: str, model
+) -> _ListenerNonPersistentState:
+    return _ListenerNonPersistentState()
+
+
+class TransformerListener:
     """A layer that gets fed its answers from an upstream Transformer component.
 
     The TransformerListener layer is used as a sublayer within a component such
@@ -162,66 +177,127 @@ class TransformerListener(Model):
     gradients back upstream.
     """
 
-    upstream_name: str
-    _batch_id: Optional[int]
-    _outputs: Optional[TransformerModelOutput]
-    _backprop: Optional[Callable[[List[List[Ragged]], Tuple[int]], Any]]
+    SENTINEL = "_TRANSFORMER_LISTENER"
+    USE_DOC_ANNOTATIONS_FOR_PREDICTION = "_USE_DOC_ANNOTATIONS_FOR_PREDICTION"
 
     @classmethod
-    def get_batch_id(cls, inputs: Iterable[Doc]) -> int:
+    def is_listener(cls, model: Model) -> bool:
+        return cls.SENTINEL in model.attrs
+
+    @classmethod
+    def init_state(cls, listener: TransformerListenerModelT, upstream_name: str = "*"):
+        """Initializes the listener model."""
+        listener.attrs["_upstream_name"] = upstream_name
+        listener.attrs[cls.SENTINEL] = True
+        listener.attrs[cls.USE_DOC_ANNOTATIONS_FOR_PREDICTION] = True
+        listener.attrs["_state"] = _ListenerNonPersistentState()
+
+    @classmethod
+    def use_doc_annotations_for_prediction(
+        cls, listener: TransformerListenerModelT
+    ) -> bool:
+        """If True, the listener will perform its operations on the transformer output
+        annotations stored on the Doc objects. Otherwise, it will perform its operations
+        on the outputs that were stored directly in it using `TransformerListener.receive`."""
+        return listener.attrs[cls.USE_DOC_ANNOTATIONS_FOR_PREDICTION]
+
+    @classmethod
+    def set_use_doc_annotations_for_prediction(
+        cls, listener: TransformerListenerModelT, new_value: bool
+    ):
+        listener.attrs[cls.USE_DOC_ANNOTATIONS_FOR_PREDICTION] = new_value
+
+    @classmethod
+    def get_upstream_name(cls, listener: TransformerListenerModelT) -> str:
+        return listener.attrs["_upstream_name"]
+
+    @staticmethod
+    def get_batch_id(listener: TransformerListenerModelT) -> Optional[int]:
+        state: _ListenerNonPersistentState = listener.attrs["_state"]
+        return state.batch_id
+
+    @staticmethod
+    def get_output(
+        listener: TransformerListenerModelT,
+    ) -> Optional[TransformerModelOutput]:
+        state: _ListenerNonPersistentState = listener.attrs["_state"]
+        return state.outputs
+
+    @staticmethod
+    def get_backprop(
+        listener: TransformerListenerModelT,
+    ) -> Optional[Callable[[List[List[Ragged]], Tuple[int]], Any]]:
+        state: _ListenerNonPersistentState = listener.attrs["_state"]
+        return state.backprop
+
+    @staticmethod
+    def calculate_batch_id(inputs: Iterable[Doc]) -> int:
         """Calculate a content-sensitive hash of the batch of documents, to check
         whether the next batch of documents is unexpected.
         """
         return sum(sum(token.orth for token in doc) for doc in inputs)
 
+    @staticmethod
     def receive(
-        self,
+        listener: TransformerListenerModelT,
         batch_id: int,
         outputs: TransformerModelOutput,
         backprop: Callable[[List[List[Ragged]], Tuple[int]], Any],
     ) -> None:
-        """Store a batch of training predictions and a backprop callback. The
-        predictions and callback are produced by the upstream Transformer component,
+        """Store a batch of training predictions and a backprop callback in the listener.
+        The predictions and callback are produced by the upstream Transformer component,
         and later will be used when the listener's component's model is called.
         """
-        self._batch_id = batch_id
-        self._outputs = outputs
-        self._backprop = backprop
+        state: _ListenerNonPersistentState = listener.attrs["_state"]
+        state.batch_id = batch_id
+        state.outputs = outputs
+        state.backprop = backprop
 
-    def verify_inputs(self, inputs: Iterable[Doc]) -> bool:
+    @classmethod
+    def verify_inputs(
+        cls, listener: TransformerListenerModelT, inputs: Iterable[Doc]
+    ) -> bool:
         """Check that the batch of Doc objects matches the ones we have a
         prediction for.
         """
-        if self._batch_id is None and self._outputs is None:
+        batch_id = cls.get_batch_id(listener)
+        outputs = cls.get_output(listener)
+
+        if batch_id is None and outputs is None:
             raise ValueError(SpacyErrors.E954)
         else:
-            batch_id = self.get_batch_id(inputs)
-            if batch_id != self._batch_id:
-                raise ValueError(
-                    SpacyErrors.E953.format(id1=batch_id, id2=self._batch_id)
-                )
+            batch_id = cls.calculate_batch_id(inputs)
+            if batch_id != batch_id:
+                raise ValueError(SpacyErrors.E953.format(id1=batch_id, id2=batch_id))
             else:
                 return True
 
+    @staticmethod
+    def clear_state(
+        listener: TransformerListenerModelT,
+    ):
+        state: _ListenerNonPersistentState = listener.attrs["_state"]
+        state.batch_id = None
+        state.outputs = None
+        state.backprop = None
 
-class TransformerLayersListener(TransformerListener):
-    """Passes through the pooled representations of all transformer layers.
 
-    Requires its upstream Transformer component to return all layer outputs from
-    its model.
-    """
-
+class TransformerLayersListener:
     name = "transformer_layers_listener"
 
-    def __init__(
-        self,
+    @classmethod
+    def new(
+        cls,
         upstream_name: str,
         pooling: PoolingModelT,
         width: int,
         layers: int,
         grad_factor: float,
-    ) -> None:
-        """
+    ) -> TransformerListenerModelT:
+        """Construct a transformer listener that passes through the pooled representations
+        of all transformer layers. Requires its upstream Transformer component to return all
+        layer outputs from its model.
+
         upstream_name (str):
             A string to identify the 'upstream' Transformer component
             to communicate with. The upstream name should either be the wildcard
@@ -242,10 +318,9 @@ class TransformerLayersListener(TransformerListener):
         grad_factor (float):
             Factor to multiply gradients with.
         """
-        Model.__init__(
-            self,
-            name=self.name,
-            forward=tranformer_layers_listener_forward,
+        model: TransformerListenerModelT = Model(
+            name=cls.name,
+            forward=cls.forward,
             dims={"nO": width},
             layers=[with_ragged_layers(pooling)],
             attrs={
@@ -254,82 +329,91 @@ class TransformerLayersListener(TransformerListener):
             },
             refs={"pooling": pooling},
         )
-        self.upstream_name = upstream_name
-        self._batch_id = None
-        self._outputs = None
-        self._backprop = None
+        TransformerListener.init_state(model, upstream_name=upstream_name)
+        return model
+
+    @staticmethod
+    def forward(
+        model: TransformerListenerModelT, docs: Iterable[Doc], is_train: bool
+    ) -> Tuple[List[List[Floats2d]], Callable[[Any], Any]]:
+        pooling: WithRaggedLayersModelT = model.layers[0]
+        grad_factor: float = model.attrs["grad_factor"]
+        n_layers: int = model.attrs["layers"]
+
+        _outputs = TransformerListener.get_output(model)
+        _backprop = TransformerListener.get_backprop(model)
+
+        if is_train:
+            assert _outputs is not None
+            if _outputs.last_layer_only:
+                raise ValueError(
+                    Errors.E012.format(listener_name="TransformerLayersListener")
+                )
+
+            TransformerListener.verify_inputs(model, docs)
+
+            Y, backprop_pooling = pooling(_outputs.all_outputs, is_train)
+
+            def backprop(dY):
+                dX = backprop_pooling(dY)
+
+                if grad_factor != 1.0:
+                    for dX_doc in dX:
+                        for dX_layer in dX_doc:
+                            dX_layer.data *= grad_factor
+
+                outputs_to_backprop = tuple(i for i in range(0, _outputs.num_outputs))
+                dX = _backprop(dX, outputs_to_backprop=outputs_to_backprop)
+
+                TransformerListener.clear_state(model)
+                return dX
+
+            return Y, backprop
+
+        else:
+            if TransformerListener.use_doc_annotations_for_prediction(model):
+                width = model.get_dim("nO")
+
+                no_trf_data = [doc._.trf_data is None for doc in docs]
+                if any(no_trf_data):
+                    assert all(no_trf_data)
+                    return [
+                        [model.ops.alloc2f(len(doc), width) for _ in range(n_layers)]
+                        for doc in docs
+                    ], lambda dY: []
+
+                if any(doc._.trf_data.last_layer_only for doc in docs):
+                    raise ValueError(
+                        Errors.E012.format(listener_name="TransformerLayersListener")
+                    )
+
+                return pooling.predict(docs), lambda dY: []
+            else:
+                assert _outputs is not None
+                TransformerListener.verify_inputs(model, docs)
+                outputs: Tuple[List[List[Floats2d]], Callable[[Any], Any]] = (
+                    pooling.predict(_outputs.all_outputs),
+                    lambda dY: [],
+                )
+                TransformerListener.clear_state(model)
+                return outputs
 
 
-def tranformer_layers_listener_forward(
-    model: TransformerLayersListener, docs: Iterable[Doc], is_train: bool
-) -> Tuple[List[List[Floats2d]], Callable[[Any], Any]]:
-    pooling: WithRaggedLayersModelT = model.layers[0]
-    grad_factor: float = model.attrs["grad_factor"]
-    n_layers: int = model.attrs["layers"]
-
-    if is_train:
-        assert model._outputs is not None
-        if model._outputs.last_layer_only:
-            raise ValueError(
-                Errors.E012.format(listener_name="TransformerLayersListener")
-            )
-
-        model.verify_inputs(docs)
-
-        Y, backprop_pooling = pooling(model._outputs.all_outputs, is_train)
-
-        def backprop(dY):
-            dX = backprop_pooling(dY)
-
-            if grad_factor != 1.0:
-                for dX_doc in dX:
-                    for dX_layer in dX_doc:
-                        dX_layer.data *= grad_factor
-
-            outputs_to_backprop = tuple(i for i in range(0, model._outputs.num_outputs))
-            dX = model._backprop(dX, outputs_to_backprop=outputs_to_backprop)
-
-            model._batch_id = None
-            model._outputs = None
-            model._backprop = None
-
-            return dX
-
-        return Y, backprop
-    else:
-        width = model.get_dim("nO")
-
-        no_trf_data = [doc._.trf_data is None for doc in docs]
-        if any(no_trf_data):
-            assert all(no_trf_data)
-            return [
-                [model.ops.alloc2f(len(doc), width) for _ in range(n_layers)]
-                for doc in docs
-            ], lambda dY: []
-
-        if any(doc._.trf_data.last_layer_only for doc in docs):
-            raise ValueError(
-                Errors.E012.format(listener_name="TransformerLayersListener")
-            )
-
-        return pooling.predict(docs), lambda dY: []
-
-
-class LastTransformerLayerListener(TransformerListener):
-    """Extracts the output of the last transformer layer and performs pooling over the
-    individual pieces of each Doc token, returning their corresponding representations.
-    """
-
+class LastTransformerLayerListener:
     name = "last_transformer_layer_listener"
 
-    def __init__(
-        self,
+    @classmethod
+    def new(
+        cls,
         upstream_name: str,
         pooling: PoolingModelT,
         width: int,
         grad_factor: float,
-    ) -> None:
-        """
+    ) -> TransformerListenerModelT:
+        """Construct a transformer listener that extracts the output of the last transformer
+        layer and performs pooling over the individual pieces of each Doc token, returning their
+        corresponding representations.
+
         upstream_name (str):
             A string to identify the 'upstream' Transformer component
             to communicate with. The upstream name should either be the wildcard
@@ -347,75 +431,84 @@ class LastTransformerLayerListener(TransformerListener):
         grad_factor (float):
             Factor to multiply gradients with.
         """
-        Model.__init__(
-            self,
-            name=self.name,
-            forward=last_transformer_layer_listener_forward,
+        model: TransformerListenerModelT = Model(
+            name=cls.name,
+            forward=cls.forward,
             dims={"nO": width},
             layers=[with_ragged_last_layer(pooling)],
             attrs={"grad_factor": grad_factor},
             refs={"pooling": pooling},
         )
-        self.upstream_name = upstream_name
-        self._batch_id = None
-        self._outputs = None
-        self._backprop = None
+        TransformerListener.init_state(model, upstream_name=upstream_name)
+        return model
+
+    @staticmethod
+    def forward(
+        model: TransformerListenerModelT, docs: Iterable[Doc], is_train: bool
+    ) -> Tuple[List[Floats2d], Callable[[Any], Any]]:
+        pooling: WithRaggedLastLayerModelT = model.layers[0]
+        grad_factor: float = model.attrs["grad_factor"]
+
+        _outputs = TransformerListener.get_output(model)
+        _backprop = TransformerListener.get_backprop(model)
+
+        if is_train:
+            assert _outputs is not None
+            TransformerListener.verify_inputs(model, docs)
+
+            Y, backprop_pooling = pooling(_outputs.last_hidden_layer_states, is_train)
+
+            def backprop(dY):
+                dX_pooling = backprop_pooling(dY)
+                if grad_factor != 1.0:
+                    for dx in dX_pooling:
+                        dx.data *= grad_factor
+                dX = _backprop([[d] for d in dX_pooling], outputs_to_backprop=(-1,))
+                TransformerListener.clear_state(model)
+
+                return dX
+
+            return Y, backprop
+        else:
+            if TransformerListener.use_doc_annotations_for_prediction(model):
+                width = model.get_dim("nO")
+
+                no_trf_data = [doc._.trf_data is None for doc in docs]
+                if any(no_trf_data):
+                    assert all(no_trf_data)
+                    return [
+                        model.ops.alloc2f(len(doc), width) for doc in docs
+                    ], lambda dY: []
+
+                return pooling.predict(docs), lambda dY: []
+            else:
+                assert _outputs is not None
+                TransformerListener.verify_inputs(model, docs)
+                outputs: Tuple[List[Floats2d], Callable[[Any], Any]] = (
+                    pooling.predict(_outputs.last_hidden_layer_states),
+                    lambda dY: [],
+                )
+                TransformerListener.clear_state(model)
+                return outputs
 
 
-def last_transformer_layer_listener_forward(
-    model: LastTransformerLayerListener, docs: Iterable[Doc], is_train: bool
-) -> Tuple[List[Floats2d], Callable[[Any], Any]]:
-    pooling: WithRaggedLastLayerModelT = model.layers[0]
-    grad_factor: float = model.attrs["grad_factor"]
-
-    if is_train:
-        model.verify_inputs(docs)
-        assert model._outputs is not None
-        Y, backprop_pooling = pooling(model._outputs.last_hidden_layer_states, is_train)
-
-        def backprop(dY):
-            dX_pooling = backprop_pooling(dY)
-            if grad_factor != 1.0:
-                for dx in dX_pooling:
-                    dx.data *= grad_factor
-            dX = model._backprop([[d] for d in dX_pooling], outputs_to_backprop=(-1,))
-            model._batch_id = None
-            model._outputs = None
-            model._backprop = None
-            return dX
-
-        return Y, backprop
-    else:
-        width = model.get_dim("nO")
-
-        no_trf_data = [doc._.trf_data is None for doc in docs]
-        if any(no_trf_data):
-            assert all(no_trf_data)
-            return [model.ops.alloc2f(len(doc), width) for doc in docs], lambda dY: []
-
-        return pooling.predict(docs), lambda dY: []
-
-
-class ScalarWeightingListener(TransformerListener):
-    """Calculates a weighted representation of all transformer layer outputs and
-    performs pooling over the individual pieces of each Doc token, returning their
-    corresponding representations.
-
-    Requires its upstream Transformer component to return all layer outputs from
-    its model.
-    """
-
+class ScalarWeightingListener:
     name = "scalar_weighting_listener"
 
-    def __init__(
-        self,
+    @classmethod
+    def new(
+        cls,
         upstream_name: str,
         weighting: ScalarWeightModelT,
         pooling: PoolingModelT,
         width: int,
         grad_factor: float,
-    ) -> None:
-        """
+    ) -> TransformerListenerModelT:
+        """Construct a transformer listener that calculates a weighted representation
+        of all transformer layer outputs and performs pooling over the individual pieces
+        of each Doc token, returning their corresponding representations. Requires its
+        upstream Transformer component to return all layer outputs from its model.
+
         upstream_name (str):
             A string to identify the 'upstream' Transformer component
             to communicate with. The upstream name should either be the wildcard
@@ -435,75 +528,244 @@ class ScalarWeightingListener(TransformerListener):
         grad_factor (float):
             Factor to multiply gradients with.
         """
-        Model.__init__(
-            self,
-            name=self.name,
-            forward=scalar_weighting_listener_forward,
+        model: TransformerListenerModelT = Model(
+            name=cls.name,
+            forward=cls.forward,
             dims={"nO": width},
             layers=[weighting, with_ragged_last_layer(pooling)],
             attrs={
                 "grad_factor": grad_factor,
             },
         )
-        self.upstream_name = upstream_name
-        self._batch_id = None
-        self._outputs = None
-        self._backprop = None
+        TransformerListener.init_state(model, upstream_name=upstream_name)
+        return model
+
+    @staticmethod
+    def forward(
+        model: TransformerListenerModelT, docs: Iterable[Doc], is_train: bool
+    ) -> Tuple[List[Floats2d], Callable[[Any], Any]]:
+        weighting: ScalarWeightModelT = model.layers[0]
+        pooling: WithRaggedLastLayerModelT = model.layers[1]
+        grad_factor: float = model.attrs["grad_factor"]
+
+        _outputs = TransformerListener.get_output(model)
+        _backprop = TransformerListener.get_backprop(model)
+
+        if is_train:
+            assert _outputs is not None
+            if _outputs.last_layer_only:
+                raise ValueError(
+                    Errors.E012.format(listener_name="ScalarWeightingListener")
+                )
+            TransformerListener.verify_inputs(model, docs)
+
+            Y_weighting: ScalarWeightOutT = []
+            weighting_inputs = _outputs.all_outputs
+            outputs_to_backprop = tuple(i for i in range(_outputs.num_outputs))
+
+            Y_weighting, backprop_weighting = weighting(weighting_inputs, is_train)
+            Y, backprop_pooling = pooling(Y_weighting, is_train)
+
+            def backprop(dYs):
+                dX_pooling = backprop_pooling(dYs)
+                dX_weighting = backprop_weighting(dX_pooling)
+
+                if grad_factor != 1.0:
+                    for dx_inner in dX_weighting:
+                        for dx in dx_inner:
+                            dx.data *= grad_factor
+
+                dX = _backprop(dX_weighting, outputs_to_backprop=outputs_to_backprop)
+                TransformerListener.clear_state(model)
+                return dX
+
+            return Y, backprop
+        else:
+            if TransformerListener.use_doc_annotations_for_prediction(model):
+                width = model.get_dim("nO")
+
+                no_trf_data = [doc._.trf_data is None for doc in docs]
+                if any(no_trf_data):
+                    assert all(no_trf_data)
+                    return [
+                        model.ops.alloc2f(len(doc), width) for doc in docs
+                    ], lambda dY: []
+
+                if any(doc._.trf_data.last_layer_only for doc in docs):
+                    raise ValueError(
+                        Errors.E012.format(listener_name="ScalarWeightingListener")
+                    )
+
+                Y_weighting = weighting.predict(
+                    [doc._.trf_data.all_outputs for doc in docs]
+                )
+                Y = pooling.predict(Y_weighting)
+
+                return Y, lambda dX: []
+            else:
+                assert _outputs is not None
+                TransformerListener.verify_inputs(model, docs)
+                Y_weighting = weighting.predict(_outputs.all_outputs)
+                outputs: Tuple[List[Floats2d], Callable[[Any], Any]] = (
+                    pooling.predict(Y_weighting),
+                    lambda dY: [],
+                )
+                TransformerListener.clear_state(model)
+                return outputs
 
 
-def scalar_weighting_listener_forward(
-    model: ScalarWeightingListener, docs: Iterable[Doc], is_train: bool
-) -> Tuple[List[Floats2d], Callable[[Any], Any]]:
-    weighting: ScalarWeightModelT = model.layers[0]
-    pooling: WithRaggedLastLayerModelT = model.layers[1]
-    grad_factor: float = model.attrs["grad_factor"]
+class WrappedTransformerAndListener(WrappedTransformerAndListenerModelT):
+    """Wraps a transformer model and a compatible listener. Exclusively used when replacing
+    listeners of a shared transformer pipeline."""
 
-    if is_train:
-        assert model._outputs is not None
-        if model._outputs.last_layer_only:
-            raise ValueError(
-                Errors.E012.format(listener_name="ScalarWeightingListener")
-            )
+    name = "wrapped_transformer_and_listener"
 
-        model.verify_inputs(docs)
+    def __init__(
+        self,
+        transformer: TransformerModelT,
+        listener: TransformerListenerModelT,
+        frozen: bool = False,
+    ) -> None:
+        """
+        transformer (TransformerModelT):
+            Transformer model to wrap.
+        listener (TransformerListenerModelT):
+            Listener model to wrap.
+        frozen (bool):
+            If the transformer is frozen.
+        """
+        Model.__init__(
+            self,
+            name=self.name,
+            init=wrapped_transformer_and_listener_init,
+            forward=wrapped_transformer_and_listener_forward,
+            dims={"nO": listener.get_dim("nO")},
+            layers=[transformer, listener],
+        )
 
-        Y_weighting: ScalarWeightOutT = []
-        weighting_inputs = model._outputs.all_outputs
-        outputs_to_backprop = tuple(i for i in range(model._outputs.num_outputs))
+        # Ensure that the transformer returns the required outputs.
+        transformer.attrs["_all_layer_outputs"] = listener.name in (
+            ScalarWeightingListener.name,
+            TransformerLayersListener.name,
+        )
 
-        Y_weighting, backprop_weighting = weighting(weighting_inputs, is_train)
-        Y, backprop_pooling = pooling(Y_weighting, is_train)
+        # Freeze the embedded transformer if the source pipe was frozen.
+        transformer.attrs["_frozen"] = frozen
 
-        def backprop(dYs):
-            dX_pooling = backprop_pooling(dYs)
-            dX_weighting = backprop_weighting(dX_pooling)
+        # Remove the marker from the wrapped listener so that it doesn't
+        # get registered to any upstream transformer pipes.
+        assert TransformerListener.SENTINEL in listener.attrs
+        del listener.attrs[TransformerListener.SENTINEL]
 
-            if grad_factor != 1.0:
-                for dx_inner in dX_weighting:
-                    for dx in dx_inner:
-                        dx.data *= grad_factor
+        # Ensure that the listener directly reads from the last batch of transformer
+        # outputs stored on it during prediction. If we don't do this, the wrapped
+        # listener will end up using the annotations of the last upstream transformer
+        # pipe that set the  `trf_data` annotation on the Doc object.
+        assert TransformerListener.use_doc_annotations_for_prediction(listener)
+        TransformerListener.set_use_doc_annotations_for_prediction(listener, False)
 
-            dX = model._backprop(dX_weighting, outputs_to_backprop=outputs_to_backprop)
-            model._batch_id = None
-            model._outputs = None
-            model._backprop = None
-            return dX
+    @property
+    def frozen_transformer(self) -> bool:
+        return self.layers[0].attrs["_frozen"]
 
-        return Y, backprop
+    @frozen_transformer.setter
+    def frozen_transformer(self, value: bool):
+        self.layers[0].attrs["_frozen"] = value
+
+
+def wrapped_transformer_and_listener_init(model: WrappedTransformerAndListener, X, Y):
+    transformer: TransformerModelT = model.layers[0]
+    listener: TransformerListenerModelT = model.layers[1]
+
+    transformer.init(X=X, Y=Y)
+    listener.init(X=X, Y=Y)
+
+
+def wrapped_transformer_and_listener_forward(
+    model: WrappedTransformerAndListener,
+    docs: WrappedTransformerAndListenerInT,
+    is_train: bool,
+) -> Tuple[WrappedTransformerAndListenerOutT, WrappedTransformerAndListenerBackpropT]:
+    transformer: TransformerModelT = model.layers[0]
+    listener: TransformerListenerModelT = model.layers[1]
+    frozen: bool = transformer.attrs["_frozen"]
+    ops = model.ops
+
+    # Follows the same process as `Transformer.update()`.
+    if frozen:
+        outputs = transformer.predict(docs)
+        bp_outputs = None
+        d_outputs = None
     else:
-        width = model.get_dim("nO")
+        outputs, bp_outputs = transformer(docs, is_train)
+        d_outputs = [
+            [Ragged(ops.alloc_f(t2v.dataXd.shape), t2v.lengths) for t2v in doc_layers]
+            for doc_layers in outputs.all_outputs
+        ]
 
-        no_trf_data = [doc._.trf_data is None for doc in docs]
-        if any(no_trf_data):
-            assert all(no_trf_data)
-            return [model.ops.alloc2f(len(doc), width) for doc in docs], lambda dY: []
+    def backprop(
+        one_d_outputs: List[List[Ragged]], outputs_to_backprop: Tuple[int, ...]
+    ) -> Any:
+        nonlocal d_outputs
+        nonlocal frozen
 
-        if any(doc._.trf_data.last_layer_only for doc in docs):
-            raise ValueError(
-                Errors.E012.format(listener_name="ScalarWeightingListener")
-            )
+        if frozen:
+            return []
 
-        Y_weigthing = weighting.predict([doc._.trf_data.all_outputs for doc in docs])
-        Y = pooling.predict(Y_weigthing)
+        assert bp_outputs is not None
+        assert d_outputs is not None
+        for i in range(len(one_d_outputs)):
+            for j in outputs_to_backprop:
+                d_outputs[i][j].data += one_d_outputs[i][j].data
 
-        return Y, lambda dX: []
+        d_docs = bp_outputs(d_outputs)
+        return d_docs
+
+    # Set the output directly on the listener so that it can use them for both
+    # training/backprop and prediction.
+    TransformerListener.receive(
+        listener,
+        batch_id=TransformerListener.calculate_batch_id(docs),
+        outputs=outputs,
+        backprop=backprop,
+    )
+    listener_outputs, bp_listener_outputs = listener(docs, is_train)
+    return listener_outputs, bp_listener_outputs
+
+
+def replace_listener_callback(
+    copied_trf_model: TransformerModelT,
+    trf_listener: TransformerListenerModelT,
+    trf_pipe: Any,
+):
+    # To avoid cyclic imports.
+    from ..pipeline.transformer import Transformer
+
+    assert isinstance(trf_pipe, Transformer)
+    assert TransformerListener.is_listener(trf_listener)
+
+    copied_trf_listener = trf_listener.copy()
+    wrapper = WrappedTransformerAndListener(
+        transformer=copied_trf_model,
+        listener=copied_trf_listener,
+        frozen=trf_pipe.frozen,
+    )
+    return wrapper
+
+
+def replace_listener_cfg_callback(trf_model_cfg, trf_listener_model_cfg):
+    result = trf_model_cfg.copy()
+
+    trf_model_cfg_arch = trf_model_cfg["@architectures"].split(".")
+    assert len(trf_model_cfg_arch) == 3 and trf_model_cfg_arch[-2].endswith(
+        "Transformer"
+    )
+    trf_listener_model_cfg_arch = trf_listener_model_cfg["@architectures"].split(".")
+    assert len(trf_listener_model_cfg_arch) == 3 and trf_listener_model_cfg_arch[
+        -2
+    ].endswith("Listener")
+
+    # The transformer model entrypoint should have a `wrapped_listener` parameter
+    # that we can use to append the listener's config.
+    result["wrapped_listener"] = trf_listener_model_cfg
+    return result

--- a/spacy_curated_transformers/models/types.py
+++ b/spacy_curated_transformers/models/types.py
@@ -1,12 +1,14 @@
 from typing import Any, Callable, Iterable, List, Union
 
 from spacy.tokens.doc import Doc
+
 from thinc.model import Model
 from thinc.types import Floats2d, Ints1d, Ragged
 
 from .output import TransformerModelOutput
 
 PoolingModelT = Model[Ragged, Floats2d]
+TransformerListenerModelT = Model[List[Doc], List[Floats2d]]
 
 WithRaggedLayersInT = Union[Iterable[Doc], Iterable[Iterable[Ragged]]]
 WithRaggedLayersOutT = List[List[Floats2d]]  # Doc -> Layer -> Representation
@@ -51,3 +53,11 @@ TransformerModelT = Model[TransformerInT, TransformerOutT]
 ScalarWeightInT = List[List[Ragged]]  # Doc -> Layer -> Representation
 ScalarWeightOutT = List[Ragged]  # Doc -> Weighted Representation
 ScalarWeightModelT = Model[ScalarWeightInT, ScalarWeightOutT]
+
+# Only used when replacing listeners.
+WrappedTransformerAndListenerInT = List[Doc]
+WrappedTransformerAndListenerOutT = List[Floats2d]
+WrappedTransformerAndListenerBackpropT = Callable[[List[List[Floats2d]]], Any]
+WrappedTransformerAndListenerModelT = Model[
+    WrappedTransformerAndListenerInT, WrappedTransformerAndListenerOutT
+]

--- a/spacy_curated_transformers/pipeline/transformer.py
+++ b/spacy_curated_transformers/pipeline/transformer.py
@@ -12,16 +12,18 @@ from typing import (
 )
 
 from spacy import Errors, Language, Vocab
-from spacy.tokens import Doc
 from spacy.pipeline import TrainablePipe
+from spacy.tokens import Doc
 from spacy.training import Example, validate_examples, validate_get_examples
 from spacy.util import minibatch
+
 from thinc.api import Config, Optimizer, set_dropout_rate
 from thinc.model import Model
 from thinc.types import Ragged
 
-from ..models.output import DocTransformerOutput, TransformerModelOutput
 from ..models.listeners import TransformerListener
+from ..models.output import DocTransformerOutput, TransformerModelOutput
+from ..models.types import TransformerListenerModelT
 
 DEFAULT_CONFIG_STR = """
     [transformer]
@@ -117,7 +119,7 @@ class Transformer(TrainablePipe):
         self.vocab = vocab
         self.model = model
         self.name = name
-        self.listener_map: Dict[str, List[TransformerListener]] = {}
+        self.listener_map: Dict[str, List[TransformerListenerModelT]] = {}
         self.cfg: Dict[str, Any] = {}
 
         _install_extensions()
@@ -126,9 +128,9 @@ class Transformer(TrainablePipe):
         self._set_model_all_layer_outputs(all_layer_outputs)
 
     @property
-    def listeners(self) -> List[TransformerListener]:
+    def listeners(self) -> List[TransformerListenerModelT]:
         """
-        RETURNS (List[TransformerListener]):
+        RETURNS (List[TransformerListenerModelT]):
             The listener models listening to this component. Usually internals.
         """
         return [m for c in self.listening_components for m in self.listener_map[c]]
@@ -141,14 +143,18 @@ class Transformer(TrainablePipe):
         """
         return list(self.listener_map.keys())
 
-    def add_listener(self, listener: TransformerListener, component_name: str) -> None:
+    def add_listener(
+        self, listener: TransformerListenerModelT, component_name: str
+    ) -> None:
         """Add a listener for a downstream component. Usually internals."""
+        assert TransformerListener.is_listener(listener)
+
         self.listener_map.setdefault(component_name, [])
         if listener not in self.listener_map[component_name]:
             self.listener_map[component_name].append(listener)
 
     def remove_listener(
-        self, listener: TransformerListener, component_name: str
+        self, listener: TransformerListenerModelT, component_name: str
     ) -> bool:
         """Remove a listener for a downstream component. Usually internals.
 
@@ -166,7 +172,7 @@ class Transformer(TrainablePipe):
 
     def find_listeners(self, component: Any) -> None:
         """Walk over a model of a processing component, looking for layers that
-        are TransformerListener subclasses that have an upstream_name that matches
+        are transformer listeners that have an upstream_name that matches
         this component. Listeners can also set their upstream_name attribute to
         the wildcard string '*' to match any `Transformer`.
         You're unlikely to ever need multiple `Transformer` components, so it's
@@ -176,8 +182,8 @@ class Transformer(TrainablePipe):
         if isinstance(getattr(component, "model", None), Model):
             for node in component.model.walk():
                 if (
-                    isinstance(node, TransformerListener)
-                    and node.upstream_name in names
+                    TransformerListener.is_listener(node)
+                    and TransformerListener.get_upstream_name(node) in names
                 ):
                     self.add_listener(node, component.name)
 
@@ -298,11 +304,13 @@ class Transformer(TrainablePipe):
             docs, losses, sgd=sgd
         )
 
-        batch_id = TransformerListener.get_batch_id(docs)
+        batch_id = TransformerListener.calculate_batch_id(docs)
         for listener in self.listeners[:-1]:
-            listener.receive(batch_id, outputs, accum_func)
+            TransformerListener.receive(listener, batch_id, outputs, accum_func)
         if self.listeners:
-            self.listeners[-1].receive(batch_id, outputs, backprop_func)
+            TransformerListener.receive(
+                self.listeners[-1], batch_id, outputs, backprop_func
+            )
         return losses
 
     def get_loss(self, examples: Iterable[Example], scores: Any) -> None:

--- a/spacy_curated_transformers/tests/pipeline/test_transformer.py
+++ b/spacy_curated_transformers/tests/pipeline/test_transformer.py
@@ -1,27 +1,34 @@
-from typing import Dict, Any
 from functools import partial
+from typing import Any, Dict
+
+import numpy
 import pytest
 import spacy
+import torch
 from spacy import Config, util
+from spacy.language import Language
 from spacy.training import Example
 from spacy.training.initialize import init_nlp
 from spacy.training.loop import train
-from spacy.language import Language
 from spacy.util import registry as spacy_registry
-import torch
-
+from spacy_curated_transformers._compat import has_hf_transformers, transformers
 from spacy_curated_transformers.models.architectures import (
-    build_camembert_transformer_model_v1,
-    build_xlmr_transformer_model_v1,
     build_bert_transformer_model_v1,
+    build_camembert_transformer_model_v1,
     build_roberta_transformer_model_v1,
+    build_xlmr_transformer_model_v1,
 )
 from spacy_curated_transformers.models.hf_loader import (
     build_hf_transformer_encoder_loader_v1,
 )
+from spacy_curated_transformers.models.listeners import (
+    TransformerListener,
+    WrappedTransformerAndListener,
+)
 from spacy_curated_transformers.models.with_strided_spans import (
     build_with_strided_spans_v1,
 )
+from spacy_curated_transformers.pipeline.transformer import make_transformer
 from spacy_curated_transformers.tokenization import (
     build_bert_wordpiece_encoder_v1,
     build_byte_bpe_encoder_v1,
@@ -29,15 +36,14 @@ from spacy_curated_transformers.tokenization import (
     build_hf_piece_encoder_loader_v1,
     build_xlmr_sentencepiece_encoder_v1,
 )
-from spacy_curated_transformers.pipeline.transformer import make_transformer
 from spacy_curated_transformers.tokenization.sentencepiece_encoder import (
     build_sentencepiece_encoder_loader_v1,
 )
 from spacy_curated_transformers.util import create_gradual_transformer_unfreezing
-from spacy_curated_transformers._compat import has_hf_transformers, transformers
 
-from ..util import torch_assertclose
+from thinc.model import Model
 
+from ..util import make_tempdir, torch_assertclose
 
 cfg_string_last_layer_listener = """
     # LastTransformerLayerListener
@@ -559,3 +565,119 @@ def test_gradual_transformer_unfreezing(test_dir):
 
     with pytest.raises(ValueError):
         create_gradual_transformer_unfreezing({"transformer": 5, "*": 4})
+
+
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.parametrize(
+    ["cfg_string", "listener_name", "listener_entrypoint"],
+    [
+        (
+            cfg_string_last_layer_listener,
+            "last_transformer_layer_listener",
+            "spacy-curated-transformers.LastTransformerLayerListener.v1",
+        ),
+        (
+            cfg_string_scalar_weighting_layer_listener,
+            "scalar_weighting_listener",
+            "spacy-curated-transformers.ScalarWeightingListener.v1",
+        ),
+    ],
+)
+def test_replace_listeners(cfg_string, listener_name, listener_entrypoint):
+    orig_config = Config().from_str(cfg_string)
+    nlp = util.load_model_from_config(orig_config, auto_fill=True, validate=True)
+    text = "This is awesome"
+    examples = [Example.from_dict(nlp.make_doc(text), {"tags": ["A", "B", "C"]})]
+    optimizer = nlp.initialize(lambda: examples)
+
+    # verify correct configuration with transformer listener
+    transformer = nlp.get_pipe("transformer")
+    tagger = nlp.get_pipe("tagger")
+
+    tagger_tok2vec = tagger.model.get_ref("tok2vec")
+
+    assert TransformerListener.is_listener(tagger_tok2vec)
+    assert transformer.listener_map["tagger"][0] == tagger_tok2vec
+    assert isinstance(transformer.model, Model)
+    assert transformer.model.name == "transformer_model"
+    assert (
+        nlp.config["components"]["transformer"]["model"]["@architectures"]
+        == "spacy-curated-transformers.BertTransformer.v1"
+    )
+    assert (
+        nlp.config["components"]["tagger"]["model"]["tok2vec"]["@architectures"]
+        == listener_entrypoint
+    )
+
+    # train pipe before replacing listeners
+    for i in range(5):
+        losses = {}
+        nlp.update(examples, sgd=optimizer, losses=losses)
+        doc = nlp(text)
+
+    preds = [t.tag_ for t in doc]
+    doc_tensor = tagger_tok2vec.predict([doc])
+
+    # replace listener and verify predictions are still the same
+    transformer.frozen = True
+    nlp.replace_listeners("transformer", "tagger", ["model.tok2vec"])
+    tagger = nlp.get_pipe("tagger")
+    tagger_tok2vec = tagger.model.get_ref("tok2vec")
+    assert isinstance(tagger_tok2vec, WrappedTransformerAndListener)
+    assert tagger_tok2vec.frozen_transformer
+    assert tagger_tok2vec.layers[0].name == "transformer_model"
+    assert tagger_tok2vec.layers[1].name == listener_name
+    assert (
+        nlp.config["components"]["tagger"]["model"]["tok2vec"]["@architectures"]
+        == "spacy-curated-transformers.BertTransformer.v1"
+    )
+    assert (
+        nlp.config["components"]["tagger"]["model"]["tok2vec"]["wrapped_listener"][
+            "@architectures"
+        ]
+        == listener_entrypoint
+    )
+    doc2 = nlp(text)
+    assert preds == [t.tag_ for t in doc2]
+    pred_tensor = tagger_tok2vec.predict([doc2])
+    numpy.testing.assert_array_equal(doc_tensor, pred_tensor)
+
+    optimizer = nlp.resume_training()
+    trf_output_frozen = tagger_tok2vec.layers[0].predict([doc2])
+    for i in range(5):
+        losses = {}
+        nlp.update(examples, sgd=optimizer, losses=losses)
+        assert losses["tagger"] > 0.0
+    trf_output_frozen_after_update = tagger_tok2vec.layers[0].predict([doc2])
+
+    for x, y in zip(
+        trf_output_frozen.all_outputs, trf_output_frozen_after_update.all_outputs
+    ):
+        for x1, y1 in zip(x, y):
+            numpy.testing.assert_array_equal(x1.dataXd, y1.dataXd)
+
+    tagger_tok2vec.frozen_transformer = False
+    trf_output = tagger_tok2vec.layers[0].predict([doc2])
+    # attempt training with the new pipeline
+    for i in range(5):
+        losses = {}
+        nlp.update(examples, sgd=optimizer, losses=losses)
+        assert losses["tagger"] > 0.0
+    trained_trf_output = tagger_tok2vec.layers[0].predict([doc2])
+
+    for x, y in zip(trf_output.all_outputs, trained_trf_output.all_outputs):
+        for x1, y1 in zip(x, y):
+            assert not numpy.array_equal(x1.dataXd, y1.dataXd)
+
+    # ensure IO goes OK
+    doc_tensor_trained = tagger_tok2vec.predict([doc])
+
+    with make_tempdir() as d:
+        file_path = d / "trained_nlp"
+        nlp.to_disk(file_path)
+        nlp2 = util.load_model_from_path(file_path)
+        doc3 = nlp2(text)
+        tagger2 = nlp2.get_pipe("tagger")
+        tagger_tok2vec2 = tagger2.model.get_ref("tok2vec")
+        pred_tensor = tagger_tok2vec2.predict([doc3])
+        numpy.testing.assert_array_equal(doc_tensor_trained, pred_tensor)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->
Multiple changes were required to facilitate this:

* All transformer model entrypoints now have a `wrapped_listener` optional parameter. This parameter is only meant to be used by the machinery that performs the listener replacement.
* Listeners are no longer subclasses of the `TransformerListener` class. Previously, the `TransformerListener` class subclassed `Model` and stored some state as instance attributes. To perform the replacement, the original listener instance in the downstream component needs to be (deep)copied. However, the implementation of `Model.copy` doesn't support classes that subclass `Model` - it merely performs deepcopies of the different `Model` instance attributes and initializes a new `Model` instance with them. What this results in is the loss of any state that was directly stored on the listener instance such as `upstream_name`, `name`, etc.

  To workaround this limitation, all listener state is now directly stored in `Model.attrs`. This ensures that no persistent state is lost between copies.
* A new `WrappedTransformerAndListener` class has been introduced to be used as the replacement model for the downstream component's original listener. This wraps the upstream transformer pipe's model and the original listener. During training and prediction, it calls the wrapped transformer and directly passes the outputs to the wrapped listener. Gradients are additionally allocated during training, and during prediction, the wrapped listener is instructed to ignore any transformer annotations present on the `Doc`s and use the ones directly stored in the listener.

This PR depends on the following: 
* https://github.com/explosion/spaCy/pull/12785
* https://github.com/explosion/curated-tokenizers/pull/44

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->
Enhancement

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
