### PR TITLE
Added support for electra tokenizer as a special case of BERT tokenizer

### DIFF
--- a/spacy_curated_transformers/tests/tokenization/test_wordpiece_encoder.py
+++ b/spacy_curated_transformers/tests/tokenization/test_wordpiece_encoder.py
@@ -48,6 +48,33 @@ def test_wordpiece_encoder_hf_model(sample_docs):
         [101, 3570, 1195, 1209, 3940, 185, 5926, 2744, 7329, 119, 102],
     )
 
+@pytest.mark.slow
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+def test_wordpiece_encoder_hf_model_w_electra(sample_docs):
+    ops = get_current_ops()
+    encoder = build_wordpiece_encoder_v1()
+    encoder.init = build_hf_piece_encoder_loader_v1(name="google/electra-small-discriminator")
+    encoder.initialize()
+
+    encoding = encoder.predict(sample_docs)
+
+    assert isinstance(encoding, list)
+    assert len(encoding) == 2
+
+    assert isinstance(encoding[0], Ragged)
+    ops.xp.testing.assert_array_equal(
+        encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    )
+    ops.xp.testing.assert_array_equal(
+        encoding[0].dataXd, [101, 146, 1486, 170, 1873, 1114, 170, 16737, 119, 102]
+    )
+
+    ops.xp.testing.assert_array_equal(encoding[1].lengths, [1, 1, 1, 1, 1, 3, 1, 1, 1])
+    ops.xp.testing.assert_array_equal(
+        encoding[1].dataXd,
+        [101, 3570, 1195, 1209, 3940, 185, 5926, 2744, 7329, 119, 102],
+    )
+
 
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")

--- a/spacy_curated_transformers/tests/tokenization/test_wordpiece_encoder.py
+++ b/spacy_curated_transformers/tests/tokenization/test_wordpiece_encoder.py
@@ -48,12 +48,15 @@ def test_wordpiece_encoder_hf_model(sample_docs):
         [101, 3570, 1195, 1209, 3940, 185, 5926, 2744, 7329, 119, 102],
     )
 
+
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_wordpiece_encoder_hf_model_w_electra(sample_docs):
     ops = get_current_ops()
     encoder = build_wordpiece_encoder_v1()
-    encoder.init = build_hf_piece_encoder_loader_v1(name="google/electra-small-discriminator")
+    encoder.init = build_hf_piece_encoder_loader_v1(
+        name="google/electra-small-discriminator"
+    )
     encoder.initialize()
 
     encoding = encoder.predict(sample_docs)

--- a/spacy_curated_transformers/tests/tokenization/test_wordpiece_encoder.py
+++ b/spacy_curated_transformers/tests/tokenization/test_wordpiece_encoder.py
@@ -49,8 +49,8 @@ def test_wordpiece_encoder_hf_model(sample_docs):
     )
 
 
-# @pytest.mark.slow
-# @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+@pytest.mark.slow
+@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_wordpiece_encoder_hf_model_w_electra(sample_docs):
     ops = get_current_ops()
     encoder = build_wordpiece_encoder_v1()

--- a/spacy_curated_transformers/tests/tokenization/test_wordpiece_encoder.py
+++ b/spacy_curated_transformers/tests/tokenization/test_wordpiece_encoder.py
@@ -49,8 +49,8 @@ def test_wordpiece_encoder_hf_model(sample_docs):
     )
 
 
-@pytest.mark.slow
-@pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
+# @pytest.mark.slow
+# @pytest.mark.skipif(not has_hf_transformers, reason="requires huggingface transformers")
 def test_wordpiece_encoder_hf_model_w_electra(sample_docs):
     ops = get_current_ops()
     encoder = build_wordpiece_encoder_v1()
@@ -68,15 +68,17 @@ def test_wordpiece_encoder_hf_model_w_electra(sample_docs):
     ops.xp.testing.assert_array_equal(
         encoding[0].lengths, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
     )
+    print(encoding[0].dataXd)
     ops.xp.testing.assert_array_equal(
-        encoding[0].dataXd, [101, 146, 1486, 170, 1873, 1114, 170, 16737, 119, 102]
+        encoding[0].dataXd, [101, 1045, 2387, 1037, 2611, 2007, 1037, 12772, 1012, 102]
     )
 
-    ops.xp.testing.assert_array_equal(encoding[1].lengths, [1, 1, 1, 1, 1, 3, 1, 1, 1])
+    ops.xp.testing.assert_array_equal(encoding[1].lengths, [1, 1, 1, 1, 1, 1, 1, 1, 1])
     ops.xp.testing.assert_array_equal(
         encoding[1].dataXd,
-        [101, 3570, 1195, 1209, 3940, 185, 5926, 2744, 7329, 119, 102],
+        [101, 2651, 2057, 2097, 4521, 26202, 4605, 1012, 102],
     )
+    print(encoding[1].dataXd)
 
 
 @pytest.mark.slow

--- a/spacy_curated_transformers/tokenization/hf_loader.py
+++ b/spacy_curated_transformers/tokenization/hf_loader.py
@@ -1,5 +1,5 @@
 import json
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 from .._compat import has_hf_transformers, transformers
 from .bbpe_encoder import ByteBPEProcessor
@@ -18,7 +18,6 @@ if has_hf_transformers:
     )
 else:
     SUPPORTED_TOKENIZERS = ()  # type: ignore
-from typing import Union
 
 
 def build_hf_piece_encoder_loader_v1(
@@ -51,8 +50,8 @@ def build_hf_piece_encoder_loader_v1(
 def _convert_encoder(
     model: Tok2PiecesModelT, tokenizer: "transformers.PreTrainedTokenizerBase"
 ) -> Tok2PiecesModelT:
-    if isinstance(tokenizer, transformers.BertTokenizerFast) or isinstance(
-        tokenizer, transformers.ElectraTokenizerFast
+    if isinstance(
+        tokenizer, (transformers.BertTokenizerFast, transformers.ElectraTokenizerFast)
     ):
         return _convert_wordpiece_encoder(model, tokenizer)
     elif isinstance(tokenizer, transformers.RobertaTokenizerFast):

--- a/spacy_curated_transformers/tokenization/hf_loader.py
+++ b/spacy_curated_transformers/tokenization/hf_loader.py
@@ -14,9 +14,11 @@ if has_hf_transformers:
         transformers.XLMRobertaTokenizerFast,
         transformers.CamembertTokenizerFast,
         transformers.BertJapaneseTokenizer,
+        transformers.ElectraTokenizerFast,
     )
 else:
     SUPPORTED_TOKENIZERS = ()  # type: ignore
+from typing import Union
 
 
 def build_hf_piece_encoder_loader_v1(
@@ -49,7 +51,9 @@ def build_hf_piece_encoder_loader_v1(
 def _convert_encoder(
     model: Tok2PiecesModelT, tokenizer: "transformers.PreTrainedTokenizerBase"
 ) -> Tok2PiecesModelT:
-    if isinstance(tokenizer, transformers.BertTokenizerFast):
+    if isinstance(tokenizer, transformers.BertTokenizerFast) or isinstance(
+        tokenizer, transformers.ElectraTokenizerFast
+    ):
         return _convert_wordpiece_encoder(model, tokenizer)
     elif isinstance(tokenizer, transformers.RobertaTokenizerFast):
         return _convert_byte_bpe_encoder(model, tokenizer)
@@ -99,7 +103,10 @@ def _convert_sentencepiece_encoder(
 
 
 def _convert_wordpiece_encoder(
-    model: Tok2PiecesModelT, tokenizer: "transformers.BertTokenizerFast"
+    model: Tok2PiecesModelT,
+    tokenizer: Union[
+        "transformers.BertTokenizerFast", "transformers.ElectraTokenizerFast"
+    ],
 ) -> Tok2PiecesModelT:
     # Seems like we cannot get the vocab file name for a BERT vocabulary? So,
     # instead, copy the vocabulary.


### PR DESCRIPTION
Added support for the ELECTRA tokenizer. The ELECTRA models is waiting for the ELECTRA [PR](https://github.com/explosion/curated-transformers/pull/358) on curated transformers.

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [ ] My changes don't require a change to the documentation, or if they do, I've added all required information.
  - I have not added the documentation required for ELECTRA as it required the PR of curated transformers
