### PR TITLE
Make `DocTransformerOutput` serializable with msgpack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 curated-transformers>=0.1.0,<0.2.0
-curated-tokenizers>=0.0.8,<0.1.0
+curated-tokenizers>=0.0.9,<0.1.0
 spacy>=3.7.0.dev0,<4.0.0
 thinc>=8.1.6,<9.1.0
 srsly

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
     curated-transformers>=0.1.0,<0.2.0
-    curated-tokenizers>=0.0.7,<0.1.0
+    curated-tokenizers>=0.0.9,<0.1.0
     spacy>=3.7.0.dev0,<4.0.0
     torch>=1.12.0
 

--- a/spacy_curated_transformers/models/output.py
+++ b/spacy_curated_transformers/models/output.py
@@ -107,7 +107,7 @@ def serialize_transformer_data(obj: DocTransformerOutput, chain=None):
     return obj if chain is None else chain(obj)
 
 
-@srsly.msgpack_decoders("doctransformeroutput")
+@srsly.msgpack_decoders("doc_transformer_output")
 def deserialize_transformer_data(obj, chain=None):
     if "__doc_transformer_output__" in obj:
         return DocTransformerOutput(all_outputs=[], last_layer_only=False).from_dict(

--- a/spacy_curated_transformers/tests/pipeline/test_transformer.py
+++ b/spacy_curated_transformers/tests/pipeline/test_transformer.py
@@ -5,8 +5,6 @@ from typing import Any, Dict
 import numpy
 import pytest
 import spacy
-from thinc.api import CupyOps, get_current_ops
-from thinc.backends import get_array_ops
 import torch
 from spacy import Config, util
 from spacy.language import Language
@@ -15,6 +13,8 @@ from spacy.training import Example
 from spacy.training.initialize import init_nlp
 from spacy.training.loop import train
 from spacy.util import registry as spacy_registry
+from thinc.api import CupyOps, get_current_ops
+from thinc.backends import get_array_ops
 from thinc.model import Model
 
 from spacy_curated_transformers._compat import has_hf_transformers, transformers

--- a/spacy_curated_transformers/tests/pipeline/test_transformer.py
+++ b/spacy_curated_transformers/tests/pipeline/test_transformer.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 import numpy
 import pytest
 import spacy
+from thinc.api import CupyOps, get_current_ops
 import torch
 from spacy import Config, util
 from spacy.language import Language
@@ -218,6 +219,10 @@ def test_tagger(cfg_string):
 @pytest.mark.parametrize(
     "cfg_string",
     [cfg_string_last_layer_listener, cfg_string_scalar_weighting_layer_listener],
+)
+@pytest.mark.skipif(
+    isinstance(get_current_ops(), CupyOps),
+    reason="multiprocessing and GPU support are incompatible",
 )
 def test_tagger_multiprocessing(cfg_string):
     model = create_tagger(cfg_string)

--- a/spacy_curated_transformers/tests/pipeline/test_transformer.py
+++ b/spacy_curated_transformers/tests/pipeline/test_transformer.py
@@ -6,9 +6,11 @@ import numpy
 import pytest
 import spacy
 from thinc.api import CupyOps, get_current_ops
+from thinc.backends import get_array_ops
 import torch
 from spacy import Config, util
 from spacy.language import Language
+from spacy.tokens import Doc
 from spacy.training import Example
 from spacy.training.initialize import init_nlp
 from spacy.training.loop import train
@@ -513,10 +515,20 @@ def test_transformer_pipe_outputs():
     assert all([doc._.trf_data.last_layer_only for doc in docs]) == True
     assert all([len(doc._.trf_data.all_outputs) == 1 for doc in docs]) == True
 
+    serialized = [doc.to_bytes() for doc in docs]
+    deserialized = [Doc(nlp.vocab).from_bytes(doc_bytes) for doc_bytes in serialized]
+    for doc, doc_deserialized in zip(docs, deserialized):
+        _assert_doc_model_output_equal(doc, doc_deserialized)
+
     pipe = make_transformer(nlp, "transformer", model, all_layer_outputs=True)
     docs = list(pipe.pipe(docs))
     assert all([not doc._.trf_data.last_layer_only for doc in docs]) == True
     assert all([len(doc._.trf_data.all_outputs) == 12 + 1 for doc in docs]) == True
+
+    serialized = [doc.to_bytes() for doc in docs]
+    deserialized = [Doc(nlp.vocab).from_bytes(doc_bytes) for doc_bytes in serialized]
+    for doc, doc_deserialized in zip(docs, deserialized):
+        _assert_doc_model_output_equal(doc, doc_deserialized)
 
 
 cfg_string_gradual_unfreezing = (
@@ -752,3 +764,16 @@ def test_transformer_add_pipe():
         ]
         == DEFAULT_CONFIG["transformer"]["model"]["with_spans"]["@architectures"]
     )
+
+
+def _assert_doc_model_output_equal(doc1: Doc, doc2: Doc):
+    output1 = doc1._.trf_data
+    output2 = doc2._.trf_data
+
+    assert output1.last_layer_only == output2.last_layer_only
+    assert len(output1.all_outputs) == len(output2.all_outputs)
+
+    for layer1, layer2 in zip(output1.all_outputs, output2.all_outputs):
+        ops = get_array_ops(layer1.dataXd)
+        ops.xp.testing.assert_allclose(layer1.dataXd, layer2.dataXd)
+        ops.xp.testing.assert_array_equal(layer1.lengths, layer2.lengths)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

This makes `Doc` objects with `spacy-curated-transformers` outputs msgpack-serializable. This is also one of the changes necessary to make spaCy multiprocessing work with `spacy-curated-transformers`.

See: https://github.com/explosion/spaCy/issues/13238

**Draft:** needs a new `curated-tokenizers` release to make piecer serialization work.

### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Feature

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
