### PR TITLE
Bring back `curated_encoder` prefix

### DIFF
--- a/spacy_curated_transformers/models/hf_loader.py
+++ b/spacy_curated_transformers/models/hf_loader.py
@@ -24,7 +24,7 @@ def build_hf_transformer_encoder_loader_v1(
     """
 
     def load(model, X=None, Y=None):
-        encoder = model.shims[0]._model
+        encoder = model.shims[0]._model.curated_encoder
         assert isinstance(encoder, FromHFHub)
         device = model.shims[0].device
         encoder.from_hf_hub_(name=name, revision=revision, device=device)

--- a/spacy_curated_transformers/tests/conftest.py
+++ b/spacy_curated_transformers/tests/conftest.py
@@ -40,7 +40,6 @@ def pytest_runtest_setup(item):
 
 @pytest.fixture
 def test_dir(request):
-    print(request.fspath)
     return Path(request.fspath).parent
 
 

--- a/spacy_curated_transformers/tests/models/test_transformer_model.py
+++ b/spacy_curated_transformers/tests/models/test_transformer_model.py
@@ -210,7 +210,9 @@ def test_encoder_prefix(test_config):
         intermediate_width=37,
         num_hidden_layers=4,
         num_attention_heads=4,
-        piece_encoder=piece_encoder, vocab_size=vocab_size, with_spans=with_spans
+        piece_encoder=piece_encoder,
+        vocab_size=vocab_size,
+        with_spans=with_spans,
     )
 
     for name, _ in model.get_ref("transformer").shims[0]._model.named_parameters():

--- a/spacy_curated_transformers/tests/models/test_transformer_model.py
+++ b/spacy_curated_transformers/tests/models/test_transformer_model.py
@@ -180,8 +180,6 @@ def test_pytorch_checkpoint_loader(test_config):
     model.initialize()
 
 
-@pytest.mark.slow
-@pytest.mark.skipif(not has_huggingface_hub, reason="requires huggingface hub")
 @pytest.mark.parametrize(
     "test_config",
     [
@@ -208,6 +206,10 @@ def test_encoder_prefix(test_config):
     # Curated Transformers needs the config to get the model hyperparameters.
     with_spans = build_with_strided_spans_v1(stride=96, window=128)
     model = model_factory(
+        hidden_width=32,
+        intermediate_width=37,
+        num_hidden_layers=4,
+        num_attention_heads=4,
         piece_encoder=piece_encoder, vocab_size=vocab_size, with_spans=with_spans
     )
 

--- a/spacy_curated_transformers/tests/models/test_transformer_model.py
+++ b/spacy_curated_transformers/tests/models/test_transformer_model.py
@@ -178,3 +178,40 @@ def test_pytorch_checkpoint_loader(test_config):
         "spacy-curated-transformers.PyTorchCheckpointLoader.v1"
     )(path=Path(checkpoint_path))
     model.initialize()
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not has_huggingface_hub, reason="requires huggingface hub")
+@pytest.mark.parametrize(
+    "test_config",
+    [
+        (
+            build_albert_transformer_model_v1,
+            build_sentencepiece_encoder_v1(),
+            1000,
+        ),
+        (
+            build_bert_transformer_model_v1,
+            build_bert_wordpiece_encoder_v1(),
+            1000,
+        ),
+        (
+            build_roberta_transformer_model_v1,
+            build_byte_bpe_encoder_v1(),
+            1000,
+        ),
+    ],
+)
+def test_encoder_prefix(test_config):
+    model_factory, piece_encoder, vocab_size = test_config
+
+    # Curated Transformers needs the config to get the model hyperparameters.
+    with_spans = build_with_strided_spans_v1(stride=96, window=128)
+    model = model_factory(
+        piece_encoder=piece_encoder, vocab_size=vocab_size, with_spans=with_spans
+    )
+
+    for name, _ in model.get_ref("transformer").shims[0]._model.named_parameters():
+        assert name.startswith(
+            "curated_encoder."
+        ), f"Parameter name '{name} does not start with 'curated_encoder'"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

<!--- Use this section to describe your changes. If your changes required
testing, include information about the testing environment and the tests you
ran. If your test fixes a bug reported in an issue, don't forget to include the
issue number. If your PR is still a work in progress, that's totally fine – just
include a note to let us know. -->

Curated Transformers for spaCy 3.x used to have a `curated_encoder` prefix that we used in e.g. the discriminative learning rate schedule. Curated Transformers doesn't use such a prefix since 1.0. Add a small wrapper to bring back the prefix, so that we can distinguish transformer parameters from other parameters.


### Types of change

<!-- What type of change does your PR cover? Is it a bug fix, an enhancement
or new feature, or a change to the documentation? -->

Bugfix.

## Checklist

<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I confirm that I have the right to submit this contribution under the project's MIT license.
- [x] I ran the tests, and all new and existing tests passed.
- [x] My changes don't require a change to the documentation, or if they do, I've added all required information.
